### PR TITLE
Fix typo in LitleOnline::LitleOnlineRequest#sale

### DIFF
--- a/lib/LitleOnlineRequest.rb
+++ b/lib/LitleOnlineRequest.rb
@@ -49,7 +49,7 @@ module LitleOnline
       add_transaction_info(transaction, options)
 
       transaction.fraudCheck          = FraudCheck.from_hash(options,'fraudCheck')
-      transaction.payPalOrderComplete = options['paPpalOrderComplete']
+      transaction.payPalOrderComplete = options['payPalOrderComplete']
       transaction.payPalNotes         = options['payPalNotes']
 
       commit(transaction, :sale, options)


### PR DESCRIPTION
From [Litle_XML_Reference_Guide_XML8.13_V2.24.pdf](https://github.com/LitleCo/litle-xml/blob/master/reference_guides/Litle_XML_Reference_Guide_XML8.13_V2.24.pdf)

4.163 payPalOrderComplete

The payPalOrderComplete element is an optional child of both the capture and sale elements, but is required to close a PayPal order. Set the value to true to close the order, when you have fulfilled the order and do not need to send any further auths or deposits against it. Set the value to false to keep the order open for additional auths or deposits.
