### PR TITLE
configuration: allow specification of an external logger

### DIFF
--- a/lib/Configuration.rb
+++ b/lib/Configuration.rb
@@ -30,6 +30,11 @@ require 'yaml'
 #
 module LitleOnline
   class Configuration
+    class << self
+      # External logger, if specified
+      attr_accessor :logger
+    end
+
     def config
       begin
         if !(ENV['LITLE_CONFIG_DIR'].nil?)

--- a/lib/LitleXmlMapper.rb
+++ b/lib/LitleXmlMapper.rb
@@ -23,6 +23,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 =end
 
+require 'logger'
+
 #
 # Handles round trip of transactions
 # Maps the request to Litle XML -> Sends XML payload to Litle via HTTP(S) -> formats XML response into a Ruby hash and returns it
@@ -30,20 +32,33 @@ OTHER DEALINGS IN THE SOFTWARE.
 module LitleOnline
   class LitleXmlMapper
     def LitleXmlMapper.request(request_xml, config_hash)
-  
-      # create a Litle XML request from the nested hashes
-      if(config_hash['printxml'])
-        puts request_xml
-      end
+      logger = initialize_logger(config_hash)
+
+      logger.debug request_xml
       # get the Litle Online Response from the API server over HTTP
       response_xml = Communications.http_post(request_xml,config_hash)
-      if(config_hash['printxml'])
-        puts response_xml
-      end
+      logger.debug response_xml
+
       # create response object from xml returned form the Litle API
       response_object = XMLObject.new(response_xml)
       
       return response_object
+    end
+
+    private
+
+    def self.initialize_logger(config_hash)
+      # Sadly, this needs to be static (the alternative would be to change the LitleXmlMapper.request API
+      # to accept a Configuration instance instead of the config_hash)
+      Configuration.logger ||= default_logger config_hash['printxml'] ? Logger::DEBUG : Logger::INFO
+    end
+
+    def self.default_logger(level) # :nodoc:
+      logger = Logger.new(STDOUT)
+      logger.level = level
+      # Backward compatible logging format for pre 8.15
+      logger.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
+      logger
     end
   end
 end


### PR DESCRIPTION
One can now specify an external logger for XML requests and responses
by setting the logger configuration property:

  LitleOnline::Configuration.logger = Logger.new(STDOUT)

This is mainly useful for the Active Merchant integration.

The default behavior hasn't changed and the printxml config parameter is
still respected.

The implementation could be cleaner by making the logger an instance of
Configuration. This requires though that the LitleXmlMapper.request
signature changes and accepts an instance of Configuration instead of the
hash directly. I didn't implement this since I'm not sure if this API is public
and to avoid making intrusive changes in the test suite.

Signed-off-by: Pierre-Alexandre Meyer pierre@ning.com
